### PR TITLE
Autocomplete URLs by path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ interface BaseParams {
   query?: Record<string, unknown>;
 }
 
+export const methods = [ 'get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace' ] as const;
+export type Method = (typeof methods)[number];
+
 type TruncatedResponse = Omit<Response, 'arrayBuffer' | 'blob' | 'body' | 'clone' | 'formData' | 'json' | 'text'>;
 /** Infer request/response from content type */
 type Unwrap<T> = T extends {
@@ -67,6 +70,11 @@ export default function createClient<T>(defaultOptions?: ClientOptions) {
     };
     return res.ok ? { data: await res.json(), response } : { error: await res.json(), response };
   }
+
+  /** Gets a union of paths which have method */
+  type PathsWith<M extends Method> = {
+    [Path in keyof T]: T[Path] extends { [ K in M ]: unknown } ? Path : never
+  }[keyof T];
 
   type PathParams<U extends keyof T> = T[U] extends { parameters: any } ? { params: T[U]['parameters'] } : { params?: BaseParams };
   type MethodParams<U extends keyof T, M extends keyof T[U]> = T[U][M] extends {
@@ -139,35 +147,35 @@ export default function createClient<T>(defaultOptions?: ClientOptions) {
 
   return {
     /** Call a GET endpoint */
-    async get<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { get: any } ? U : never, options: FetchOptions<U, M>) {
+    async get<U extends PathsWith<'get'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'GET' });
     },
     /** Call a PUT endpoint */
-    async put<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { put: any } ? U : never, options: FetchOptions<U, M>) {
+    async put<U extends PathsWith<'put'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'PUT' });
     },
     /** Call a POST endpoint */
-    async post<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { post: any } ? U : never, options: FetchOptions<U, M>) {
+    async post<U extends PathsWith<'post'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'POST' });
     },
     /** Call a DELETE endpoint */
-    async del<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { delete: any } ? U : never, options: FetchOptions<U, M>) {
+    async del<U extends PathsWith<'delete'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'DELETE' });
     },
     /** Call a OPTIONS endpoint */
-    async options<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { options: any } ? U : never, options: FetchOptions<U, M>) {
+    async options<U extends PathsWith<'options'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'OPTIONS' });
     },
     /** Call a HEAD endpoint */
-    async head<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { head: any } ? U : never, options: FetchOptions<U, M>) {
+    async head<U extends PathsWith<'head'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'HEAD' });
     },
     /** Call a PATCH endpoint */
-    async patch<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { patch: any } ? U : never, options: FetchOptions<U, M>) {
+    async patch<U extends PathsWith<'patch'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'PATCH' });
     },
     /** Call a TRACE endpoint */
-    async trace<U extends keyof T, M extends keyof T[U]>(url: T[U] extends { trace: any } ? U : never, options: FetchOptions<U, M>) {
+    async trace<U extends PathsWith<'trace'>, M extends keyof T[U]>(url: U, options: FetchOptions<U, M>) {
       return coreFetch(url, { ...options, method: 'TRACE' });
     },
   };

--- a/test/v1.d.ts
+++ b/test/v1.d.ts
@@ -43,6 +43,64 @@ export interface paths {
       };
     };
   };
+  "/anyMethod": {
+    get: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    put: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    post: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    delete: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    options: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    head: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    patch: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+    trace: {
+      responses: {
+        200: components["responses"]["User"];
+        404: components["responses"]["Error"];
+        500: components["responses"]["Error"];
+      };
+    };
+  };
 }
 
 export type webhooks = Record<string, never>;

--- a/test/v1.yaml
+++ b/test/v1.yaml
@@ -41,6 +41,71 @@ paths:
           $ref: '#/components/responses/Error'
         500:
           $ref: '#/components/responses/Error'
+  /anyMethod:
+    get:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    put:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    post:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    delete:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    options:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    head:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    patch:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
+    trace:
+      responses:
+        200:
+          $ref: '#/components/responses/User'
+        404:
+          $ref: '#/components/responses/Error'
+        500:
+          $ref: '#/components/responses/Error'
 
 components:
   schemas:


### PR DESCRIPTION
title - fairly self-explanatory with the following images:

![image](https://user-images.githubusercontent.com/8567231/224985575-6e85967b-889f-413a-9de4-315ea0111fb6.png)

![image](https://user-images.githubusercontent.com/8567231/224985695-3b151e2e-8f4b-4938-b0bf-445fdd9c6171.png)

Broke the existing tests where `'/' as any` was used, since `any` is not assignable to `never`, so created an endpoint `/anyMethod` which has every method available on it so it wouldn't error (since any is assignable to a literal string, `/anyMethod`).