### PR TITLE
export BaseParams

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ interface ClientOptions extends RequestInit {
   baseUrl?: string;
 }
 
-interface BaseParams {
+export interface BaseParams {
   path?: Record<string, unknown>;
   query?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Changes

In a brand new Vue/Vite-based setup, creating an API client and then exporting it for use:

```
import createClient from 'openapi-fetch';
import type { paths } from './openapi-types';

const { get, post, del } = createClient<paths>({
    baseUrl: 'http://localhost:3000'
});

export default { get, post, del };
```

TypeScript throws the following error:
```
Exported variable 'get' has or is using name 'BaseParams' from external module "/Users/sean/Code/sample-app/node_modules/openapi-fetch/dist/index" but cannot be named. ts(4023)
```

Exporting `BaseParams` resolves the error.

I don't appear to have the same issue with my React Native codebase, so I think it's definitely a result of a particular `tsconfig` - but this is a brand new Vue/Vite-based setup created with their CLI and no `tsconfig` overrides.

## How to Review

_How can a reviewer review your changes? What should be kept in mind for this review?_

## Checklist

- [ ] Tests updated
- [ ] README updated
