### PR TITLE
Support setting body encoding

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,8 @@ type Unwrap<T> = T extends {
   content: { 'application/json': any };
 }
   ? T['content']['application/json']
+  : T extends { content: { 'application/json;charset=utf-8': any } }
+  ? T['content']['application/json;charset=utf-8']
   : T extends { content: { '*/*': any } }
   ? T['content']['*/*']
   : T;

--- a/test/v1.d.ts
+++ b/test/v1.d.ts
@@ -206,7 +206,7 @@ export interface components {
   requestBodies: {
     CreatePost: {
       content: {
-        "application/json": {
+        "application/json;charset=utf-8": {
           title: string;
           body: string;
           publish_date: number;

--- a/test/v1.yaml
+++ b/test/v1.yaml
@@ -162,7 +162,7 @@ components:
     CreatePost:
       required: true
       content:
-        application/json:
+        "application/json;charset=utf-8":
           schema:
             type: object
             properties:


### PR DESCRIPTION
## Changes

I updated the request/response inference to support schemas whose content types have an encoding set to `utf8` (`application/json;charset=utf-8`). 

## How to Review

I modified the test schema to have a failing test. 

## Checklist

- [X] Tests updated
- [ ] README updated
