### PR TITLE
support optional querySerializer option

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 test/v1.d.ts
+pnpm-lock.yaml

--- a/README.md
+++ b/README.md
@@ -146,6 +146,28 @@ const { data, error } = await post('/create-post', {
 
 Note in the `get()` example, the URL was actually `/post/{post_id}`, _not_ `/post/my-post`. The URL matched the OpenAPI schema definition rather than the final URL. This library will replace the path param correctly for you, automatically.
 
+### Query Parameters
+
+To customise the query parameters serialization pass in a `querySerializer` function to any fetch
+method (get, post, etc):
+
+```ts
+import createClient from 'openapi-fetch';
+import { paths } from './v1';
+
+const { get, post } = createClient<paths>();
+
+const { data, error } = await get('/post/{post_id}', {
+  params: {
+    path: { post_id: 'my-post' },
+    query: { version: 2 },
+  },
+  querySerializer: (q) => {
+    return `v=${q.version}`;
+  },
+});
+```
+
 ### 🔒 Handling Auth
 
 Authentication often requires some reactivity dependent on a token. Since this library is so low-level, there are myriad ways to handle it:

--- a/README.md
+++ b/README.md
@@ -162,9 +162,7 @@ const { data, error } = await get('/post/{post_id}', {
     path: { post_id: 'my-post' },
     query: { version: 2 },
   },
-  querySerializer: (q) => {
-    return `v=${q.version}`;
-  },
+  querySerializer: (q) => `v=${q.version}`,
 });
 ```
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -171,6 +171,27 @@ describe('get()', () => {
     // expect post_id to be encoded properly
     expect(fetchMocker.mock.calls[0][0]).toBe('/post/post%3Fid%20%3D%20%F0%9F%A5%B4');
   });
+
+  it('serializes params properly', async () => {
+    const client = createClient<paths>();
+    fetchMocker.mockResponseOnce(() => ({ status: 200, body: '{}' }));
+    await client.get('/post/{post_id}', {
+      params: { path: { post_id: 'my-post' }, query: { a: 1, b: 2 } },
+    });
+
+    expect(fetchMocker.mock.calls[0][0]).toBe('/post/my-post?a=1&b=2');
+  });
+
+  it('serializes params properly with querySerializer', async () => {
+    const client = createClient<paths>();
+    fetchMocker.mockResponseOnce(() => ({ status: 200, body: '{}' }));
+    await client.get('/post/{post_id}', {
+      params: { path: { post_id: 'my-post' }, query: { a: 1, b: 2 } },
+      querySerializer: (q) => 'asdf',
+    });
+
+    expect(fetchMocker.mock.calls[0][0]).toBe('/post/my-post?asdf');
+  });
 });
 
 describe('post()', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -187,10 +187,10 @@ describe('get()', () => {
     fetchMocker.mockResponseOnce(() => ({ status: 200, body: '{}' }));
     await client.get('/post/{post_id}', {
       params: { path: { post_id: 'my-post' }, query: { a: 1, b: 2 } },
-      querySerializer: (q) => 'asdf',
+      querySerializer: (q) => `alpha=${q.a}&beta=${q.b}`,
     });
 
-    expect(fetchMocker.mock.calls[0][0]).toBe('/post/my-post?asdf');
+    expect(fetchMocker.mock.calls[0][0]).toBe('/post/my-post?alpha=1&beta=2');
   });
 });
 


### PR DESCRIPTION
## Changes

Adds a `querySerializer` field to coreFetch options to pass in a function to serialize the query object to a query string.

## How to Review

check that this does not disrupt existing or desired behavior

## Checklist

- [x] Tests updated
- [x] README updated
