### PR TITLE
fix: should handle empty content (HTTP 204)

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -307,12 +307,22 @@ describe('delete()', () => {
       params: { path: { post_id: '123' } },
     });
 
-    // assert correct URL was called
-    expect(fetchMocker.mock.calls[0][0]).toBe('/post/123');
+    // assert correct data was returned
+    expect(data).toEqual({});
+
+    // assert error is empty
+    expect(error).toBe(undefined);
+  });
+
+  it('returns empty object on Content-Length: 0', async () => {
+    const client = createClient<paths>();
+    fetchMocker.mockResponseOnce(() => ({ headers: { 'Content-Length': 0 }, status: 200, body: '' }));
+    const { data, error, response } = await client.del('/post/{post_id}', {
+      params: { path: { post_id: '123' } },
+    });
 
     // assert correct data was returned
     expect(data).toEqual({});
-    expect(response.status).toBe(204);
 
     // assert error is empty
     expect(error).toBe(undefined);

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,9 +125,10 @@ export default function createClient<T>(options?: ClientOptions) {
       headers: baseHeaders,
       body: typeof requestBody === 'string' ? requestBody : JSON.stringify(requestBody),
     });
+    const respHeaders = res.headers;
     const response: TruncatedResponse = {
       bodyUsed: res.bodyUsed,
-      headers: res.headers,
+      headers: respHeaders,
       ok: res.ok,
       redirected: res.redirected,
       status: res.status,


### PR DESCRIPTION
## Changes

It won't throw error while handling response with no content, which is a common practice for DELETE method. Instead it will return empty in ```data``` or ```error```.

## Checklist

- [X] Tests updated
- [ ] README updated *(no need to change? )*
