### PR TITLE
Update README.md to fix type error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ import createClient from 'openapi-fetch';
 import { paths } from './v1'; // (generated from openapi-typescript)
 
 const { get, post, put, patch, del } = createClient<paths>({
-  baseURL: 'https://myserver.com/api/v1/',
+  baseUrl: 'https://myserver.com/api/v1/',
   headers: {
     Authorization: `Bearer ${import.meta.env.VITE_AUTH_TOKEN}`,
   },


### PR DESCRIPTION
Type error when copying and pasting the example led me to realize it was incorrect casing.

## Changes

The property name casing to fix type errors

## How to Review

Copy and paste the code to validate there are no typescript errors

## Checklist

- [ ] Tests updated
- [X] README updated
