### PR TITLE
Issue 27 return empty object on 204 responses

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -249,6 +249,25 @@ describe('post()', () => {
       body: { foo: 'Bar' },
     });
   });
+
+  it('returns empty object on 204', async () => {
+    const client = createClient<paths>();
+    fetchMocker.mockResponseOnce(() => ({ status: 204, body: '' }));
+    const { data, error, response } = await client.post('/create-tag/{name}', {
+      params: { path: { name: 'New Tag' } },
+      body: { description: 'This is a new tag' },
+    });
+
+    // assert correct URL was called
+    expect(fetchMocker.mock.calls[0][0]).toBe('/create-tag/New%20Tag');
+
+    // assert correct data was returned
+    expect(data).toEqual({});
+    expect(response.status).toBe(204);
+
+    // assert error is empty
+    expect(error).toBe(undefined);
+  });
 });
 
 describe('delete()', () => {
@@ -257,6 +276,24 @@ describe('delete()', () => {
     fetchMocker.mockResponseOnce(() => ({ status: 200, body: '{}' }));
     await client.del('/' as any, {});
     expect(fetchMocker.mock.calls[0][1]?.method).toBe('DELETE');
+  });
+
+  it('returns empty object on 204', async () => {
+    const client = createClient<paths>();
+    fetchMocker.mockResponseOnce(() => ({ status: 204, body: '' }));
+    const { data, error, response } = await client.del('/post/{post_id}', {
+      params: { path: { post_id: '123' } },
+    });
+
+    // assert correct URL was called
+    expect(fetchMocker.mock.calls[0][0]).toBe('/post/123');
+
+    // assert correct data was returned
+    expect(data).toEqual({});
+    expect(response.status).toBe(204);
+
+    // assert error is empty
+    expect(error).toBe(undefined);
   });
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export default function createClient<T>(options?: ClientOptions) {
       type: res.type,
       url: res.url,
     };
-    return res.ok ? { data: await res.json(), response } : { error: await res.json(), response };
+    return res.ok ? { data: res.status === 204 ? {} : await res.json(), response } : { error: await res.json(), response };
   }
 
   return {


### PR DESCRIPTION
Return `{}` for 204 responses

## Changes

This adds a check so that if the response code is 204, then an empty object is returned rather than attempting to parse the missing content.  See https://github.com/drwpow/openapi-fetch/issues/27 for further detail

## How to Review

A response with a 204 status code and no body will return `{}` in the data field.  Before the change, this will fail with a JSON parse error.

## Checklist

- [X] Tests updated
- [X] README updated (N/A)
