### PR TITLE
Improve installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,11 @@ Notice **there are no generics, and no manual typing.** Your endpoint’s exact 
 
 ## 🔧 Setup
 
-First install this package and [openapi-typescript](https://github.com/drwpow/openapi-typescript) from npm:
+First, install this package and [openapi-typescript](https://github.com/drwpow/openapi-typescript) from NPM:
 
 ```
-npm i -D openapi-fetch openapi-typescript
+npm i openapi-fetch
+npm i -D openapi-typescript
 ```
 
 Next, generate TypeScript types from your OpenAPI schema using openapi-typescript:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Notice **there are no generics, and no manual typing.** Your endpoint’s exact 
 
 ## 🔧 Setup
 
-First, install this package and [openapi-typescript](https://github.com/drwpow/openapi-typescript) from NPM:
+First, install this package and [openapi-typescript](https://github.com/drwpow/openapi-typescript) from npm:
 
 ```
 npm i openapi-fetch


### PR DESCRIPTION
- `openapi-fetch`, not `open-api-fetch`
- It should not be installed as a dev dependency.

