### PR TITLE
Fix querySerializer signature

### DIFF
--- a/.changeset/wet-boxes-fix.md
+++ b/.changeset/wet-boxes-fix.md
@@ -1,0 +1,5 @@
+---
+'openapi-fetch': patch
+---
+
+Fix querySerializer signature


### PR DESCRIPTION
## Changes

Minor TS fix where `querySerializer`’s signature accidentally got wrapped in an object.
