### PR TITLE
fix: fix request body type when optional

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,16 +34,19 @@ export type FilterKeys<Obj, Matchers> = { [K in keyof Obj]: K extends Matchers ?
 /** handle "application/json", "application/vnd.api+json", "appliacation/json;charset=utf-8" and more */
 export type JSONLike = `${string}json${string}`;
 
-// fetch types
+// general purpose types
 export type Params<O> = O extends { parameters: any } ? { params: NonNullable<O['parameters']> } : BaseParams;
-export type RequestBodyObj<O> = O extends { requestBody: any } ? O['requestBody'] : never;
+export type RequestBodyObj<O> = O extends { requestBody?: any } ? O['requestBody'] : never;
 export type RequestBodyContent<O> = undefined extends RequestBodyObj<O> ? FilterKeys<NonNullable<RequestBodyObj<O>>, 'content'> | undefined : FilterKeys<RequestBodyObj<O>, 'content'>;
 export type RequestBodyJSON<O> = FilterKeys<RequestBodyContent<O>, JSONLike> extends never ? FilterKeys<NonNullable<RequestBodyContent<O>>, JSONLike> | undefined : FilterKeys<RequestBodyContent<O>, JSONLike>;
 export type RequestBody<O> = undefined extends RequestBodyJSON<O> ? { body?: RequestBodyJSON<O> } : { body: RequestBodyJSON<O> };
 export type QuerySerializer<O> = (query: O extends { parameters: { query: any } } ? O['parameters']['query'] : Record<string, unknown>) => string;
-export type FetchOptions<T> = Params<T> & RequestBody<T> & Omit<RequestInit, 'body'> & { querySerializer?: QuerySerializer<T> };
+export type RequestOptions<T> = Params<T> & RequestBody<T> & { querySerializer?: QuerySerializer<T> };
 export type Success<O> = FilterKeys<FilterKeys<O, OkStatus>, 'content'>;
 export type Error<O> = FilterKeys<FilterKeys<O, ErrorStatus>, 'content'>;
+
+// fetch types
+export type FetchOptions<T> = RequestOptions<T> & Omit<RequestInit, 'body'>;
 export type FetchResponse<T> =
   | { data: T extends { responses: any } ? NonNullable<FilterKeys<Success<T['responses']>, JSONLike>> : unknown; error?: never; response: Response }
   | { data?: never; error: T extends { responses: any } ? NonNullable<FilterKeys<Error<T['responses']>, JSONLike>> : unknown; response: Response };

--- a/test/v1.d.ts
+++ b/test/v1.d.ts
@@ -23,6 +23,28 @@ export interface paths {
       };
     };
   };
+  "/post/optional": {
+    post: {
+      requestBody: components["requestBodies"]["CreatePostOptional"];
+      responses: {
+        201: components["responses"]["CreatePost"];
+        500: components["responses"]["Error"];
+      };
+    };
+  };
+  "/post/optional/inline": {
+    post: {
+      requestBody?: {
+        content: {
+          "application/json": components["schemas"]["Post"];
+        };
+      };
+      responses: {
+        201: components["responses"]["CreatePost"];
+        500: components["responses"]["Error"];
+      };
+    };
+  };
   "/posts": {
     get: {
       responses: {
@@ -263,6 +285,15 @@ export interface components {
   parameters: never;
   requestBodies: {
     CreatePost: {
+      content: {
+        "application/json": {
+          title: string;
+          body: string;
+          publish_date: number;
+        };
+      };
+    };
+    CreatePostOptional?: {
       content: {
         "application/json": {
           title: string;

--- a/test/v1.yaml
+++ b/test/v1.yaml
@@ -1,4 +1,6 @@
-openapi:
+openapi: 3.0.3
+info:
+  title: Test Specification
   version: '3.1'
 paths:
   /comment:
@@ -14,6 +16,27 @@ paths:
     put:
       requestBody:
         $ref: '#/components/requestBodies/CreatePost'
+      responses:
+        201:
+          $ref: '#/components/responses/CreatePost'
+        500:
+          $ref: '#/components/responses/Error'
+  /post/optional:
+    post:
+      requestBody:
+        $ref: '#/components/requestBodies/CreatePostOptional'
+      responses:
+        201:
+          $ref: '#/components/responses/CreatePost'
+        500:
+          $ref: '#/components/responses/Error'
+  /post/optional/inline:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Post'
       responses:
         201:
           $ref: '#/components/responses/CreatePost'
@@ -199,6 +222,23 @@ components:
   requestBodies:
     CreatePost:
       required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              title:
+                type: string
+              body:
+                type: string
+              publish_date:
+                type: number
+            required:
+              - title
+              - body
+              - publish_date
+    CreatePostOptional:
+      required: false
       content:
         application/json:
           schema:


### PR DESCRIPTION
## Changes

- Fix #34 by matching the optional `requestBody`
- Split typed options from `fetch()` options to make it reusable for other HTTP clients

## Checklist

- [ ] Tests updated
- [ ] README updated
