### PR TITLE
Add custom fetch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ createClient<paths>(options);
 | Name            |   Type   | Description                                                                                                                              |
 | :-------------- | :------: | :--------------------------------------------------------------------------------------------------------------------------------------- |
 | `baseUrl`       | `string` | Prefix all fetch URLs with this option (e.g. `"https://myapi.dev/v1/"`).                                                                 |
+| `fetch`         | `fetch`  | Fetch function used for requests (defaults to `globalThis.fetch`)                                                                        |
 | (Fetch options) |          | Any valid fetch option (`headers`, `mode`, `cache`, `signal` …) ([docs](https://developer.mozilla.org/en-US/docs/Web/API/fetch#options)) |
 
 ## 🎯 Project Goals

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,7 +192,7 @@ describe('client', () => {
           ok: true,
         } as Response),
     });
-    expect((await client.get('/', {})).data).toBe(data);
+    expect((await client.get('/self', {})).data).toBe(data);
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -180,6 +180,20 @@ describe('client', () => {
       })
     );
   });
+
+  it('accepts a custom fetch function', async () => {
+    const data = { works: true };
+    const client = createClient<paths>({
+      fetch: async () =>
+        Promise.resolve({
+          headers: new Headers(),
+          json: async () => data,
+          status: 200,
+          ok: true,
+        } as Response),
+    });
+    expect((await client.get('/', {})).data).toBe(data);
+  });
 });
 
 describe('get()', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ const DEFAULT_HEADERS = {
 interface ClientOptions extends RequestInit {
   /** set the common root URL for all API requests */
   baseUrl?: string;
+  /** custom fetch (defaults to globalThis.fetch) */
+  fetch?: typeof fetch;
 }
 export interface BaseParams {
   params?: { query?: Record<string, unknown> };
@@ -51,17 +53,19 @@ export type FetchResponse<T> =
   | { data: T extends { responses: any } ? NonNullable<FilterKeys<Success<T['responses']>, JSONLike>> : unknown; error?: never; response: Response }
   | { data?: never; error: T extends { responses: any } ? NonNullable<FilterKeys<Error<T['responses']>, JSONLike>> : unknown; response: Response };
 
-export default function createClient<Paths extends {}>(options?: ClientOptions) {
+export default function createClient<Paths extends {}>(clientOptions: ClientOptions = {}) {
+  const { fetch = globalThis.fetch, ...options } = clientOptions;
+
   const defaultHeaders = new Headers({
     ...DEFAULT_HEADERS,
-    ...(options?.headers ?? {}),
+    ...(options.headers ?? {}),
   });
 
   async function coreFetch<P extends keyof Paths, M extends HttpMethod>(url: P, fetchOptions: FetchOptions<M extends keyof Paths[P] ? Paths[P][M] : never>): Promise<FetchResponse<M extends keyof Paths[P] ? Paths[P][M] : unknown>> {
     const { headers, body: requestBody, params = {}, querySerializer = (q: QuerySerializer<M extends keyof Paths[P] ? Paths[P][M] : never>) => new URLSearchParams(q as any).toString(), ...init } = fetchOptions || {};
 
     // URL
-    let finalURL = `${options?.baseUrl ?? ''}${url as string}`;
+    let finalURL = `${options.baseUrl ?? ''}${url as string}`;
     if ((params as any).path) {
       for (const [k, v] of Object.entries((params as any).path)) finalURL = finalURL.replace(`{${k}}`, encodeURIComponent(String(v)));
     }


### PR DESCRIPTION
## Changes

Add `fetch` property to `ClientOptions` for custom implementations

Relates: drwpow/openapi-typescript#1125 drwpow/openapi-fetch#41 drwpow/openapi-typescript#1126

## Checklist

- [x] Tests updated
- [x] README updated
